### PR TITLE
Opencv optimizations

### DIFF
--- a/library/src/main/java/org/pattonvillerobotics/commoncode/robotclasses/opencv/relicrecovery/jewels/JewelColorDetector.java
+++ b/library/src/main/java/org/pattonvillerobotics/commoncode/robotclasses/opencv/relicrecovery/jewels/JewelColorDetector.java
@@ -257,6 +257,24 @@ public class JewelColorDetector {
         return new AnalysisResult(leftJewelColor, rightJewelColor);
     }
 
+    public AnalysisResult getAnalysis(boolean compareToTape) {
+        ColorSensorColor leftJewelColor = null;
+        ColorSensorColor rightJewelColor = null;
+
+        if (compareToTape) return getAnalysis();
+        if (redJewel == null || blueJewel == null) return new AnalysisResult();
+
+        if (redJewel.getX() < blueJewel.getX()) {
+            leftJewelColor = ColorSensorColor.RED;
+            rightJewelColor = ColorSensorColor.BLUE;
+        } else if (blueJewel.getX() < redJewel.getX()) {
+            rightJewelColor = ColorSensorColor.RED;
+            leftJewelColor = ColorSensorColor.BLUE;
+        }
+
+        return new AnalysisResult(leftJewelColor, rightJewelColor);
+    }
+
     public void setAnalysisMode(JewelAnalysisMode analysisMode) {
         this.analysisMode = analysisMode;
     }

--- a/library/src/main/java/org/pattonvillerobotics/commoncode/robotclasses/opencv/relicrecovery/jewels/JewelColorDetector.java
+++ b/library/src/main/java/org/pattonvillerobotics/commoncode/robotclasses/opencv/relicrecovery/jewels/JewelColorDetector.java
@@ -257,6 +257,14 @@ public class JewelColorDetector {
         return new AnalysisResult(leftJewelColor, rightJewelColor);
     }
 
+    /**
+     * Has the option to compare jewel locations to tape. If jewels are compared against each other
+     * instead of the tape then leftJewelColor and rightJewelColor will never evaluate to null.
+     *
+     * @param compareToTape whether or not to compare jewels to tape location
+     * @return
+     * @see #getAnalysis()
+     */
     public AnalysisResult getAnalysis(boolean compareToTape) {
         ColorSensorColor leftJewelColor = null;
         ColorSensorColor rightJewelColor = null;


### PR DESCRIPTION
Allows the phone to compare just the jewels to each other without the tape. This can speed up detection timing during autonomous to just 1 or 2 processing cycles.